### PR TITLE
fix: proxy api to avoid CORS

### DIFF
--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const API_BASE_URL = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL || 'http://blaybum.haeyul.cloud:8000';
+
+async function handleProxy(req: NextRequest, context: { params: Promise<{ path?: string[] }> }) {
+  const { path } = await context.params;
+  const segments = path ?? [];
+  const url = new URL(req.url);
+  const targetUrl = `${API_BASE_URL}/${segments.join('/')}${url.search}`;
+
+  const headers = new Headers(req.headers);
+  headers.delete('host');
+  headers.delete('content-length');
+
+  const method = req.method.toUpperCase();
+  const body = method === 'GET' || method === 'HEAD' ? undefined : await req.arrayBuffer();
+
+  const upstream = await fetch(targetUrl, {
+    method,
+    headers,
+    body: body && body.byteLength > 0 ? body : undefined,
+    redirect: 'manual',
+  });
+
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete('content-encoding');
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}
+
+export async function GET(req: NextRequest, context: { params: Promise<{ path?: string[] }> }) {
+  return handleProxy(req, context);
+}
+
+export async function POST(req: NextRequest, context: { params: Promise<{ path?: string[] }> }) {
+  return handleProxy(req, context);
+}
+
+export async function PUT(req: NextRequest, context: { params: Promise<{ path?: string[] }> }) {
+  return handleProxy(req, context);
+}
+
+export async function PATCH(req: NextRequest, context: { params: Promise<{ path?: string[] }> }) {
+  return handleProxy(req, context);
+}
+
+export async function DELETE(req: NextRequest, context: { params: Promise<{ path?: string[] }> }) {
+  return handleProxy(req, context);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,12 @@ const nextConfig: NextConfig = {
   compiler: {
     emotion: true,
   },
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'placehold.co' },
+      { protocol: 'http', hostname: 'placehold.co' },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -21,7 +21,7 @@ import type {
   ApiResponse,
 } from './types';
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://blaybum.haeyul.cloud:8000';
+const BASE_URL = '/api/proxy';
 
 async function request<T>(
   endpoint: string,


### PR DESCRIPTION
Summary:\n- Add /api/proxy route to forward API requests server-side\n- Route client API calls through proxy to avoid CORS\n- Allow placehold.co images in Next config\n\nTests:\n- docker compose up -d --build